### PR TITLE
Remove duplicate `site_admin_email` entry | #7

### DIFF
--- a/config/checklist_items.php
+++ b/config/checklist_items.php
@@ -14,11 +14,6 @@ return [
 				'description' => 'The from address in automated emails sent during registration and new password requests, and other notifications',
 			],
 			[
-				'name'        => 'site_admin_email',
-				'label'       => 'Site admin email',
-				'description' => 'The from address in automated emails sent during registration and new password requests, and other notifications',
-			],
-			[
 				'name'        => 'site_information_name',
 				'label'       => 'Verify the site title tag is correct',
 				'description' => 'Make sure the Site name field is correct.',


### PR DESCRIPTION
## Description
> When I complete all items in the (default) launch checklist, I expect to see that the list is 100% complete.

_Currently, if I complete all items in the default checklist, it will not show as 100% complete. Full details in #7._


## Related Tickets

* #7 

## Steps to Validate
1. Install and activate the plugin
2. Complete all checklist items
3. Review the "% complete" notice


