### PR TITLE
Fix fatal error when attemting to save w/ nothing checked

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -5,9 +5,9 @@ namespace WpLaunchChecklist\Launch_Checklist;
 /**
  * Get all the checklist items that have values stored.
  *
- * @return array
+ * @return mixed
  */
-function get_wp_launch_checklist_values() : array {
+function get_wp_launch_checklist_values() : mixed {
 	return get_option( WP_LAUNCH_CHECKLIST_SLUG . '_values', array() );
 }
 


### PR DESCRIPTION
## Description
> As an admin user of the plugin I need to be able to save items without error.

_When trying to get a saved option of items checked the `get_wp_launch_checklist_values()` function would fail due to string return type. To be compatible with php 7 this is set to `mixed` instead of `string|array`._

## Affected URL
N/A pull branch into a WP test site using the plugin


## Related Tickets
N/A


## Steps to Validate
1. Check some items in `/wp-admin/admin.php?page=wp_launch_checklist`, save, uncheck them and save.
2. Verify this doesn't result in a fatal error.

## Deploy Notes
_N/A._
