### PR TITLE
Add Additional Checklist Item for Pantheon HTTPS

### DIFF
--- a/config/checklist_items.php
+++ b/config/checklist_items.php
@@ -245,6 +245,11 @@ return [
 				'label'       => 'Transient API Usage',
 				'description' => 'Consider using the <a href="https://developer.wordpress.org/apis/handbook/transients/">transients api</a> for better performance.',
 			],
+			[
+				'name'        => 'enforce_https_pantheon',
+				'label'       => 'Enforce HTTPS redirects on all Pantheon hosting platforms (DEV, TEST, LIVE) within pantheon.yml',
+				'description' => 'See <a href="https://docs.pantheon.io/http-to-https#redirect-to-https-and-the-primary-domain">the documentation</a> for more information.',
+			]
 		],
 	],
 	'database' => [


### PR DESCRIPTION
## Description
Teamwork Ticket(s): [WP Launch Checklist Plugin -- Checklist item for HTTPS checks on Pantheon](https://kanopi.teamwork.com/app/tasks/29387318)

> As a plugin user I need a checklist item for pantheon environment HTTPS checks.

_The adds an additional checklist item per [this issue](https://github.com/kanopi/wp-launch-checklist/issues/11)._

## Acceptance Criteria
* Verify the checklist item makes sense for the request.
* Verify the checking and unchecking the item is saved/unsaved without issue.

## Assumptions
* N/A

## Steps to Validate
1. Download and activate the plugin in your project of choice.
2. View the checklist section illustrated in the screenshot below.
3. Verify the acceptance criteria listed above.

## Affected URL
[Docksal](https://wp.docksal.site/wp-admin/admin.php?page=wp_launch_checklist#performance-and-security)

## Screenshots
<img width="1309" alt="Screenshot 2023-12-13 at 9 28 02 AM" src="https://github.com/kanopi/wp-launch-checklist/assets/867556/36bd0f1d-53da-4d4c-89e4-0ef8f58dbf8e">


## Deploy Notes
_The readme.txt changelog will need to be updated for the next release as well as version bumps added before pushing out to the wordpress .org repository._
